### PR TITLE
Refactor to support "fit" property instead of "autoGenerateShape" and "mergeGeometry"

### DIFF
--- a/index.js
+++ b/index.js
@@ -35,7 +35,7 @@ exports.createCollisionShapes = (function() {
 
   return function(sceneRoot, options) {
     const fit = options.hasOwnProperty("fit") ? options.fit : FIT.ALL;
-    const type = options.type || TYPE.HULL;
+    let type = options.type || TYPE.HULL;
     const minHalfExtent = options.hasOwnProperty("minHalfExtent") ? options.minHalfExtent : 0;
     const maxHalfExtent = options.hasOwnProperty("maxHalfExtent") ? options.maxHalfExtent : Number.POSITIVE_INFINITY;
     const cylinderAxis = options.cylinderAxis || "y";

--- a/index.js
+++ b/index.js
@@ -112,11 +112,19 @@ exports.createCollisionShapes = (function() {
           break;
         }
         case TYPE.HULL: {
-          const hx = fit === FIT.MANUAL ? options.halfExtents : computeHalfExtents(root);
+          if (fit === FIT.MANUAL) {
+            fit = FIT.ALL;
+            console.warn("cannot use fit: manual with type: hull, switching to fit: all");
+          }
+          const hx = computeHalfExtents(root);
           collisionShape = _createHullShape(root, fit, margin, bounds, options.hullMaxVertices || 100000);
           break;
         }
         case TYPE.MESH: {
+          if (fit === FIT.MANUAL) {
+            fit = FIT.ALL;
+            console.warn("cannot use fit: manual with type: mesh, switching to fit: all");
+          }
           collisionShape = _createTriMeshShape(root, fit);
           localOffset.add(pos);
           break;

--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
 "use strict";
 /* global Ammo,THREE */
 
-const Type = (exports.Type = {
+const TYPE = (exports.TYPE = {
   BOX: "box",
   CYLINDER: "cylinder",
   SPHERE: "sphere",
@@ -11,96 +11,185 @@ const Type = (exports.Type = {
   MESH: "mesh"
 });
 
-exports.createCollisionShape = (function() {
+const FIT = (exports.FIT = {
+  ALL: "all", //A single shape is automatically sized to bound all meshes within the entity.
+  COMPOUND: "compound", //Multiple shapes are generated to bound each individual mesh within the entity.
+  MANUAL: "manual" //A single shape is sized manually. Requires halfExtents or sphereRadius.
+});
+
+exports.createCollisionShapes = (function() {
   const bounds = new THREE.Box3();
+  const localOffset = new THREE.Vector3();
+  const q = new THREE.Quaternion();
   const sphere = new THREE.Sphere();
   const halfExtents = new THREE.Vector3();
 
+  const offset = new THREE.Vector3();
+  const orientation = new THREE.Quaternion();
+
+  const matrix = new THREE.Matrix4();
+  const inverse = new THREE.Matrix4();
+  const pos = new THREE.Vector3();
+  const quat = new THREE.Quaternion();
+  const scale = new THREE.Vector3();
+
   return function(sceneRoot, options) {
-    const autoGenerateShape = options.hasOwnProperty("autoGenerateShape") ? options.autoGenerateShape : true;
-    const mergeGeometry = options.hasOwnProperty("mergeGeometry") ? options.mergeGeometry : true;
-    const type = options.type || Type.HULL;
+    const fit = options.hasOwnProperty("fit") ? options.fit : FIT.ALL;
+    const type = options.type || TYPE.HULL;
     const minHalfExtent = options.hasOwnProperty("minHalfExtent") ? options.minHalfExtent : 0;
     const maxHalfExtent = options.hasOwnProperty("maxHalfExtent") ? options.maxHalfExtent : Number.POSITIVE_INFINITY;
     const cylinderAxis = options.cylinderAxis || "y";
     const margin = options.hasOwnProperty("margin") ? options.margin : 0.01;
 
-    if ((mergeGeometry || autoGenerateShape) && !sceneRoot) {
-      console.warn("cannot use mergeGeometry or autoGenerateShape if sceneRoot is null");
+    if (options.offset) {
+      offset.set(options.offset.x, options.offset.y, options.offset.z);
+    } else {
+      offset.set(0, 0, 0);
+    }
+
+    if (options.orientation) {
+      orientation.set(options.orientation.x, options.orientation.y, options.orientation.z, options.orientation.w);
+    } else {
+      orientation.set(0, 0, 0, 1);
+    }
+
+    if (fit !== FIT.MANUAL && !sceneRoot) {
+      console.warn("cannot use all or compound fit if sceneRoot is null");
       return null;
     }
 
-    const computeRadius = function() {
-      _computeBounds(sceneRoot, mergeGeometry, bounds);
-      _computeSphere(sceneRoot, mergeGeometry, bounds, sphere);
+    const computeRadius = function(root) {
+      _computeBounds(root, fit, bounds);
+      _computeSphere(root, fit, bounds, sphere);
       return sphere.radius;
     };
 
-    const computeHalfExtents = function() {
-      _computeBounds(sceneRoot, mergeGeometry, bounds);
-      return halfExtents
+    const computeHalfExtents = function(root) {
+      _computeBounds(root, fit, bounds);
+      halfExtents
         .subVectors(bounds.max, bounds.min)
         .multiplyScalar(0.5)
         .clampScalar(minHalfExtent, maxHalfExtent);
+      localOffset
+        .addVectors(bounds.max, bounds.min)
+        .multiplyScalar(0.5)
+        .applyMatrix4(matrix);
+      return halfExtents;
     };
 
-    //TODO: Support convex hull decomposition, compound shapes, gimpact (dynamic trimesh)
-    let collisionShape;
-    switch (type) {
-      case Type.BOX: {
-        const hx = autoGenerateShape ? computeHalfExtents() : options.halfExtents;
-        collisionShape = _createBoxShape(hx);
-        break;
+    const createCollisionShape = function(root) {
+      bounds.min.set(0, 0, 0);
+      bounds.max.set(0, 0, 0);
+      localOffset.set(0, 0, 0);
+
+      let collisionShape;
+      switch (type) {
+        case TYPE.BOX: {
+          const hx = fit === FIT.MANUAL ? options.halfExtents : computeHalfExtents(root);
+          collisionShape = _createBoxShape(hx);
+          break;
+        }
+        case TYPE.CYLINDER: {
+          const hx = fit === FIT.MANUAL ? options.halfExtents : computeHalfExtents(root);
+          collisionShape = _createCylinderShape(hx, cylinderAxis);
+          break;
+        }
+        case TYPE.CAPSULE: {
+          const hx = fit === FIT.MANUAL ? options.halfExtents : computeHalfExtents(root);
+          collisionShape = _createCapsuleShape(hx, cylinderAxis);
+          break;
+        }
+        case TYPE.CONE: {
+          const hx = fit === FIT.MANUAL ? options.halfExtents : computeHalfExtents(root);
+          collisionShape = _createConeShape(hx, cylinderAxis);
+          break;
+        }
+        case TYPE.SPHERE: {
+          const radius =
+            fit === FIT.MANUAL && !isNaN(options.sphereRadius) ? options.sphereRadius : computeRadius(root);
+          collisionShape = new Ammo.btSphereShape(radius);
+          collisionShape.sphereRadius = radius;
+          break;
+        }
+        case TYPE.HULL: {
+          const hx = fit === FIT.MANUAL ? options.halfExtents : computeHalfExtents(root);
+          collisionShape = _createHullShape(root, fit, margin, bounds, options.hullMaxVertices || 100000);
+          break;
+        }
+        case TYPE.MESH: {
+          collisionShape = _createTriMeshShape(root, fit);
+          localOffset.add(pos);
+          break;
+        }
+        default:
+          console.warn(type + " is not currently supported");
+          return null;
       }
-      case Type.CYLINDER: {
-        const hx = autoGenerateShape ? computeHalfExtents() : options.halfExtents;
-        collisionShape = _createCylinderShape(hx, cylinderAxis);
-        break;
+      //TODO: Support convex hull decomposition, compound shapes, gimpact (dynamic trimesh)
+
+      collisionShape.type = type;
+      collisionShape.setMargin(margin);
+      collisionShape.destroy = () => {
+        for (let res of collisionShape.resources || []) {
+          Ammo.destroy(res);
+        }
+        Ammo.destroy(collisionShape);
+      };
+
+      const localTransform = new Ammo.btTransform();
+      const rotation = new Ammo.btQuaternion();
+      localTransform.setIdentity();
+
+      if (fit === FIT.COMPOUND) {
+        localOffset.add(offset);
+        quat.multiply(orientation);
+      } else {
+        localOffset.copy(offset);
+        quat.copy(orientation);
       }
-      case Type.CAPSULE: {
-        const hx = autoGenerateShape ? computeHalfExtents() : options.halfExtents;
-        collisionShape = _createCapsuleShape(hx, cylinderAxis);
-        break;
+
+      localTransform.getOrigin().setValue(localOffset.x, localOffset.y, localOffset.z);
+      rotation.setValue(quat.x, quat.y, quat.z, quat.w);
+
+      localTransform.setRotation(rotation);
+      Ammo.destroy(rotation);
+
+      const localScale = new Ammo.btVector3(scale.x, scale.y, scale.z);
+      collisionShape.setLocalScaling(localScale);
+      Ammo.destroy(localScale);
+
+      collisionShape.localTransform = localTransform;
+
+      return collisionShape;
+    };
+
+    const shapes = [];
+    matrix.identity();
+    if (fit === FIT.COMPOUND) {
+      inverse.getInverse(sceneRoot.matrixWorld);
+      sceneRoot.traverse(obj => {
+        if (obj.isMesh && (!THREE.Sky || obj.__proto__ != THREE.Sky.prototype)) {
+          matrix.multiplyMatrices(inverse, obj.matrixWorld);
+          matrix.decompose(pos, quat, scale);
+          shapes.push(createCollisionShape(obj));
+        }
+      });
+    } else {
+      if (fit === FIT.ALL) {
+        sceneRoot.matrixWorld.decompose(pos, quat, scale);
+      } else {
+        matrix.decompose(pos, quat, scale);
       }
-      case Type.CONE: {
-        const hx = autoGenerateShape ? computeHalfExtents() : options.halfExtents;
-        collisionShape = _createConeShape(hx, cylinderAxis);
-        break;
-      }
-      case Type.SPHERE: {
-        const radius = !isNaN(options.sphereRadius) ? options.sphereRadius : computeRadius();
-        collisionShape = new Ammo.btSphereShape(radius);
-        break;
-      }
-      case Type.HULL: {
-        collisionShape = _createHullShape(sceneRoot, mergeGeometry, margin, options.hullMaxVertices || 100000);
-        break;
-      }
-      case Type.MESH: {
-        collisionShape = _createTriMeshShape(sceneRoot, mergeGeometry);
-        break;
-      }
-      default:
-        console.warn(type + " is not currently supported");
-        return null;
+      shapes.push(createCollisionShape(sceneRoot));
     }
 
-    collisionShape.type = type;
-    collisionShape.setMargin(margin);
-    collisionShape.destroy = () => {
-      for (let res of collisionShape.resources || []) {
-        Ammo.destroy(res);
-      }
-      Ammo.destroy(collisionShape);
-    };
-
-    return collisionShape;
+    return shapes;
   };
 })();
 
 // Calls `cb(mesh)` for each mesh under `root` whose vertices we should take into account for the physics shape.
-function _iterateMeshes(root, mergeGeometry, cb) {
-  if (!mergeGeometry) {
+function _iterateMeshes(root, fit, cb) {
+  if (fit !== FIT.ALL) {
     cb(root);
   } else {
     root.traverse(obj => {
@@ -117,9 +206,9 @@ const _iterateGeometries = (function() {
   const transform = new THREE.Matrix4();
   const inverse = new THREE.Matrix4();
   const bufferGeometry = new THREE.BufferGeometry();
-  return function(root, mergeGeometry, cb) {
+  return function(root, fit, cb) {
     inverse.getInverse(root.matrixWorld);
-    _iterateMeshes(root, mergeGeometry, mesh => {
+    _iterateMeshes(root, fit, mesh => {
       const geo = mesh.geometry.isBufferGeometry ? mesh.geometry : bufferGeometry.fromGeometry(mesh.geometry);
       if (mesh !== root) {
         transform.multiplyMatrices(inverse, mesh.matrixWorld);
@@ -136,10 +225,10 @@ const _iterateGeometries = (function() {
 // Sets `target` to the bounding sphere for the geometries underneath `root`.
 const _computeSphere = (function() {
   const v = new THREE.Vector3();
-  return function(root, mergeGeometry, bounds, target) {
+  return function(root, fit, bounds, target) {
     let maxRadiusSq = 0;
     let { x: cx, y: cy, z: cz } = bounds.getCenter(target.center);
-    _iterateGeometries(root, mergeGeometry, (geo, transform) => {
+    _iterateGeometries(root, fit, (geo, transform) => {
       const components = geo.attributes.position.array;
       for (let i = 0; i < components.length; i += 3) {
         v.set(components[i], components[i + 1], components[i + 2]).applyMatrix4(transform);
@@ -157,14 +246,14 @@ const _computeSphere = (function() {
 // Sets `target` to the bounding box for the geometries underneath `root`.
 const _computeBounds = (function() {
   const v = new THREE.Vector3();
-  return function(root, mergeGeometry, target) {
+  return function(root, fit, target) {
     let minX = +Infinity;
     let minY = +Infinity;
     let minZ = +Infinity;
     let maxX = -Infinity;
     let maxY = -Infinity;
     let maxZ = -Infinity;
-    _iterateGeometries(root, mergeGeometry, (geo, transform) => {
+    _iterateGeometries(root, fit, (geo, transform) => {
       const components = geo.attributes.position.array;
       for (let i = 0; i < components.length; i += 3) {
         v.set(components[i], components[i + 1], components[i + 2]).applyMatrix4(transform);
@@ -231,17 +320,16 @@ const _createCapsuleShape = function({ x, y, z } = halfExtents, capsuleAxis) {
 };
 
 const _createHullShape = (function() {
-  const pos = new THREE.Vector3();
-  const quat = new THREE.Quaternion();
-  const scale = new THREE.Vector3();
   const vertex = new THREE.Vector3();
-  return function(root, mergeGeometry, margin, maxVertices) {
+  const center = new THREE.Vector3();
+  return function(root, fit, margin, bounds, maxVertices) {
     const btVertex = new Ammo.btVector3();
     const originalHull = new Ammo.btConvexHullShape();
     originalHull.setMargin(margin);
+    center.addVectors(bounds.max, bounds.min).multiplyScalar(0.5);
 
     let vertexCount = 0;
-    _iterateGeometries(root, mergeGeometry, geo => {
+    _iterateGeometries(root, fit, geo => {
       vertexCount += geo.attributes.position.array.length / 3;
     });
 
@@ -251,11 +339,14 @@ const _createHullShape = (function() {
     }
     const p = Math.min(1, maxVertices / vertexCount);
 
-    _iterateGeometries(root, mergeGeometry, (geo, transform) => {
+    _iterateGeometries(root, fit, (geo, transform) => {
       const components = geo.attributes.position.array;
       for (let i = 0; i < components.length; i += 3) {
         if (Math.random() <= p) {
-          vertex.set(components[i], components[i + 1], components[i + 2]).applyMatrix4(transform);
+          vertex
+            .set(components[i], components[i + 1], components[i + 2])
+            .applyMatrix4(transform)
+            .sub(center);
           btVertex.setValue(vertex.x, vertex.y, vertex.z);
           originalHull.addPoint(btVertex, i === components.length - 3); // todo: better to recalc AABB only on last geometry
         }
@@ -275,31 +366,23 @@ const _createHullShape = (function() {
       collisionShape.resources = [shapeHull];
     }
 
-    root.matrixWorld.decompose(pos, quat, scale);
-    const localScale = new Ammo.btVector3(scale.x, scale.y, scale.z);
-    collisionShape.setLocalScaling(localScale);
-
-    Ammo.destroy(localScale);
     Ammo.destroy(btVertex);
     return collisionShape;
   };
 })();
 
 const _createTriMeshShape = (function() {
-  const pos = new THREE.Vector3();
-  const quat = new THREE.Quaternion();
-  const scale = new THREE.Vector3();
   const va = new THREE.Vector3();
   const vb = new THREE.Vector3();
   const vc = new THREE.Vector3();
-  return function(root, mergeGeometry) {
+  return function(root, fit) {
     // todo: limit number of triangles?
     const bta = new Ammo.btVector3();
     const btb = new Ammo.btVector3();
     const btc = new Ammo.btVector3();
     const triMesh = new Ammo.btTriangleMesh(true, false);
 
-    _iterateGeometries(root, mergeGeometry, (geo, transform) => {
+    _iterateGeometries(root, fit, (geo, transform) => {
       const components = geo.attributes.position.array;
       if (geo.index) {
         for (let i = 0; i < geo.index.array.length; i += 3) {
@@ -329,13 +412,9 @@ const _createTriMeshShape = (function() {
 
     // todo: it's very bad to setLocalScaling on the shape after initializing, causing a needless BVH recalc --
     // we should be using triMesh.setScaling prior to building the BVH
-    root.matrixWorld.decompose(pos, quat, scale);
-    const localScale = new Ammo.btVector3(scale.x, scale.y, scale.z);
     const collisionShape = new Ammo.btBvhTriangleMeshShape(triMesh, true, true);
-    collisionShape.setLocalScaling(localScale);
     collisionShape.resources = [triMesh];
 
-    Ammo.destroy(localScale);
     Ammo.destroy(bta);
     Ammo.destroy(btb);
     Ammo.destroy(btc);

--- a/index.js
+++ b/index.js
@@ -19,7 +19,6 @@ const FIT = (exports.FIT = {
 
 exports.createCollisionShapes = (function() {
   const bounds = new THREE.Box3();
-  const shapeBounds = [];
   const localOffset = new THREE.Vector3();
   const q = new THREE.Quaternion();
   const sphere = new THREE.Sphere();
@@ -169,36 +168,12 @@ exports.createCollisionShapes = (function() {
     const shapes = [];
     matrix.identity();
     if (fit === FIT.COMPOUND) {
-      shapeBounds.length = 0;
       inverse.getInverse(sceneRoot.matrixWorld);
       sceneRoot.traverse(obj => {
         if (obj.isMesh && (!THREE.Sky || obj.__proto__ != THREE.Sky.prototype)) {
           matrix.multiplyMatrices(inverse, obj.matrixWorld);
           matrix.decompose(pos, quat, scale);
-          const shape = createCollisionShape(obj);
-
-          let addShape = true;
-          if (type !== TYPE.SPHERE && type !== TYPE.MESH) {
-            for (let i = 0; i < shapeBounds.length; i++) {
-              //Loop through all collisionShapes that have already been added to the scene and determine if this one is already enclosed by one of those.
-              //If so, don't add it.
-              //TODO: get rid of this if HACD is ever implemented.
-              if (_boxEnclosesBox(shapeBounds[i], bounds)) {
-                addShape = false;
-                break;
-              }
-            }
-
-            if (addShape) {
-              shapeBounds.push(bounds.clone());
-            }
-          }
-
-          if (addShape) {
-            shapes.push(shape);
-          } else {
-            shape.destroy();
-          }
+          shapes.push(createCollisionShape(obj));
         }
       });
     } else {
@@ -446,14 +421,3 @@ const _createTriMeshShape = (function() {
     return collisionShape;
   };
 })();
-
-const _boxEnclosesBox = function(source, target) {
-  return (
-    source.min.x <= target.min.x &&
-    source.max.x > target.max.x &&
-    source.min.y <= target.min.y &&
-    source.max.y > target.max.y &&
-    source.min.z <= target.min.z &&
-    source.max.z > target.max.z
-  );
-};


### PR DESCRIPTION
`fit` can be either `all`, `compound`, `manual`. 

fit | description
-- | --
all | A single shape is automatically sized to bound all meshes within the entity.
compound | Multiple shapes are generated to bound each individual mesh within the entity.
manual | A single shape is sized manually. Requires halfExtents or sphereRadius.

Because of `compound`, createCollisionShapes (prev: createCollisionShape) now returns a list of 1 or more btCollisionShapes. Furthermore, the localTransform of those shapes is created such that when the shape is ultimately added to a btRigidBody, the transform can be applied.

`setLocalScaling` is now also done for all shapes. 

Finally, the calculated `center` of a hull is being applied in `_createHullShape` so that hulls are properly centered.

