### PR TITLE
Don't retain btShapeHull after convex hull creation

### DIFF
--- a/index.js
+++ b/index.js
@@ -272,7 +272,7 @@ const _createHullShape = (function() {
         Ammo.getPointer(shapeHull.getVertexPointer()),
         shapeHull.numVertices()
       );
-      collisionShape.resources = [shapeHull];
+      Ammo.destroy(shapeHull); // btConvexHullShape makes a copy
     }
 
     root.matrixWorld.decompose(pos, quat, scale);


### PR DESCRIPTION
There's no benefit to having this around, because its data was already copied into `btConvexHullShape`.