### PR TITLE
Handle arrays of vertices implemented as interleaved buffer attributes

### DIFF
--- a/index.js
+++ b/index.js
@@ -688,8 +688,32 @@ export const iterateGeometries = (function() {
         }
         // todo: might want to return null xform if this is the root so that callers can avoid multiplying
         // things by the identity matrix
+
+        let vertices;
+        if (mesh.geometry.isBufferGeometry) {
+          const verticesAttribute = mesh.geometry.attributes.position;
+          if (verticesAttribute.isInterleavedBufferAttribute) {
+            //
+            // An interleaved buffer attribute shares the underlying
+            // array with other attributes. We translate it to a
+            // regular array here to not carry this logic around in
+            // the shape api.
+            //
+            vertices = [];
+            for (let i = 0; i < verticesAttribute.count; i += 3) {
+              vertices.push(verticesAttribute.getX(i));
+              vertices.push(verticesAttribute.getY(i));
+              vertices.push(verticesAttribute.getZ(i));
+            }
+          } else {
+            vertices = verticesAttribute.array;
+          }
+        } else {
+          vertices = mesh.geometry.vertices;
+        }
+
         cb(
-          mesh.geometry.isBufferGeometry ? mesh.geometry.attributes.position.array : mesh.geometry.vertices,
+          vertices,
           transform.elements,
           mesh.geometry.index ? mesh.geometry.index.array : null
         );

--- a/index.js
+++ b/index.js
@@ -669,6 +669,7 @@ const _finishCollisionShape = function(collisionShape, options, scale) {
 
 export const iterateGeometries = (function() {
   const inverse = new THREE.Matrix4();
+  const vertices = [];
   return function(root, options, cb) {
     inverse.copy(root.matrixWorld).invert();
     const scale = new THREE.Vector3();
@@ -689,7 +690,7 @@ export const iterateGeometries = (function() {
         // todo: might want to return null xform if this is the root so that callers can avoid multiplying
         // things by the identity matrix
 
-        let vertices;
+        let unInterleavedVertices;
         if (mesh.geometry.isBufferGeometry) {
           const verticesAttribute = mesh.geometry.attributes.position;
           if (verticesAttribute.isInterleavedBufferAttribute) {
@@ -699,21 +700,22 @@ export const iterateGeometries = (function() {
             // regular array here to not carry this logic around in
             // the shape api.
             //
-            vertices = [];
+            vertices.length = 0;
             for (let i = 0; i < verticesAttribute.count; i += 3) {
               vertices.push(verticesAttribute.getX(i));
               vertices.push(verticesAttribute.getY(i));
               vertices.push(verticesAttribute.getZ(i));
             }
+	    unInterleavedVertices = vertices;
           } else {
-            vertices = verticesAttribute.array;
+	    unInterleavedVertices = verticesAttribute.array;
           }
         } else {
-          vertices = mesh.geometry.vertices;
+          unInterleavedVertices = mesh.geometry.vertices;
         }
 
         cb(
-          vertices,
+          unInterleavedVertices,
           transform.elements,
           mesh.geometry.index ? mesh.geometry.index.array : null
         );

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "three-to-ammo",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "three-to-ammo",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Convert THREE.Mesh to Ammo.btCollisionShape",
   "homepage": "https://github.com/infinitelee/three-to-ammo",
   "main": "index.js",


### PR DESCRIPTION
This fixes creating collision shapes for indexed models. 

Before this change, as computing bounding box and sphere was assuming vertices to be always 3 by 3 in the array, one could either incur in out of bound errors or have their shape incorrectly calculated.